### PR TITLE
Make `platform_from_name` return remote hosts if unset

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -320,7 +320,7 @@ with Conf('flow.rc', desc='''
                 sourcing ``~/.bashrc`` (or ``~/.cshrc``) to set up the
                 environment.
             ''')
-            Conf('remote hosts', VDR.V_STRING_LIST)
+            Conf('remote hosts', VDR.V_STRING_LIST, [])
             Conf('cylc executable', VDR.V_STRING, 'cylc', desc='''
                 The ``cylc`` executable on a remote host.
 

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -56,12 +56,19 @@ def platform_from_name(platform_name=None, platforms=None):
     # defined platforms.
     for platform_name_re in reversed(list(platforms)):
         if re.fullmatch(platform_name_re, platform_name):
-            platform_data = platforms[platform_name_re]
-            if not platform_data:
-                platform_data = deepcopy(platforms['localhost'])
-                platform_data['remote hosts'] = platform_name
-            else:
-                platform_data = deepcopy(platform_data)
+            # Deepcopy prevents contaminating platforms with data
+            # from other platforms matching platform_name_re
+            platform_data = deepcopy(platforms[platform_name_re])
+
+            # If remote hosts are not filled in make remote
+            # hosts the platform name.
+            # Example: `[platforms][workplace_vm_123]<nothing>`
+            #   should create a platform where
+            #   `remote_hosts = ['workplace_vm_123']`
+            if 'remote hosts' not in platform_data.keys():
+                platform_data['remote hosts'] = [platform_name]
+
+            # Fill in the "private" name field.
             platform_data['name'] = platform_name
             return platform_data
 

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -147,7 +147,6 @@ def construct_platform_ssh_cmd(raw_cmd, platform, **kwargs):
     """
     ret = construct_ssh_cmd(
         raw_cmd,
-        user=platform['owner'],
         host=get_host_from_platform(platform),
         ssh_cmd=platform['ssh command'],
         ssh_cylc=platform['cylc executable'],

--- a/cylc/flow/scripts/cylc_check_versions.py
+++ b/cylc/flow/scripts/cylc_check_versions.py
@@ -41,7 +41,7 @@ from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.cylc_subproc import Popen, PIPE, DEVNULL
 from cylc.flow import __version__ as CYLC_VERSION
 from cylc.flow.config import SuiteConfig
-from cylc.flow.platforms import forward_lookup
+from cylc.flow.platforms import platform_from_name
 from cylc.flow.remote import construct_platform_ssh_cmd
 from cylc.flow.suite_files import parse_suite_arg
 from cylc.flow.templatevars import load_template_vars

--- a/cylc/flow/tests/test_platform_lookup.py
+++ b/cylc/flow/tests/test_platform_lookup.py
@@ -48,21 +48,24 @@ PLATFORMS = {
 
 PLATFORMS_NO_UNIQUE = {
     'sugar': {
-        'login hosts': 'localhost',
+        'remote hosts': 'localhost',
         'batch system': 'slurm'
     },
     'pepper': {
-        'login hosts': ['hpc1', 'hpc2'],
+        'remote hosts': ['hpc1', 'hpc2'],
         'batch system': 'slurm'
     },
 
 }
 
 PLATFORMS_WITH_RE = {
-    'hpc.*': {'login hosts': 'hpc1', 'batch system': 'background'},
-    'h.*': {'login hosts': 'hpc3'},
-    r'vld\d{2,3}': None,
-    'nu.*': {'batch system': 'slurm'},
+    'hpc.*': {'remote hosts': 'hpc1', 'batch system': 'background'},
+    'h.*': {'remote hosts': 'hpc3'},
+    r'vld\d{2,3}': {},
+    'nu.*': {
+        'batch system': 'slurm',
+        'remote hosts': ['localhost']
+    },
     'localhost': {
         'remote hosts': 'localhost',
         'batch system': 'background'
@@ -75,15 +78,16 @@ PLATFORMS_WITH_RE = {
     [
         (PLATFORMS_WITH_RE, "nutmeg", {
             "batch system": "slurm",
-            "name": "nutmeg"
+            "name": "nutmeg",
+            "remote hosts": ['localhost']
         }),
-        (PLATFORMS_WITH_RE, "vld798", "vld798"),
-        (PLATFORMS_WITH_RE, "vld56", "vld56"),
+        (PLATFORMS_WITH_RE, "vld798", ["vld798"]),
+        (PLATFORMS_WITH_RE, "vld56", ["vld56"]),
         (
             PLATFORMS_NO_UNIQUE,
             "sugar",
             {
-                "login hosts": "localhost",
+                "remote hosts": "localhost",
                 "batch system": "slurm",
                 "name": "sugar"
             },
@@ -93,13 +97,13 @@ PLATFORMS_WITH_RE = {
             None,
             {
                 "remote hosts": "localhost",
-                "batch system": "background",
-                "name": "localhost",
+                "batch system": "background"
             },
         ),
         (PLATFORMS, "laptop22", {
             "batch system": "background",
-            "name": "laptop22"
+            "name": "laptop22",
+            "remote hosts": ["laptop22"]
         }),
         (
             PLATFORMS,
@@ -110,10 +114,12 @@ PLATFORMS_WITH_RE = {
                 "name": "hpc1-bg"
             },
         ),
-        (PLATFORMS_WITH_RE, "hpc2", {"login hosts": "hpc3", "name": "hpc2"}),
+        (PLATFORMS_WITH_RE, "hpc2", {"remote hosts": "hpc3", "name": "hpc2"}),
     ],
 )
 def test_basic(PLATFORMS, platform, expected):
+    # n.b. The name field of the platform is set in the Globalconfig object
+    # if the name is 'localhost', so we don't test for it here.
     platform = platform_from_name(platform_name=platform, platforms=PLATFORMS)
     if isinstance(expected, dict):
         assert platform == expected
@@ -157,7 +163,7 @@ def test_similar_but_not_exact_match():
             'sugar'
         ),
         # Check that when users asks for hpc1 and pbs they get a platform
-        # with hpc1 in its list of login hosts
+        # with hpc1 in its list of remote hosts
         (
             {'batch system': 'pbs'},
             {'host': 'hpc1'},

--- a/cylc/flow/tests/test_platform_lookup.py
+++ b/cylc/flow/tests/test_platform_lookup.py
@@ -97,6 +97,7 @@ PLATFORMS_WITH_RE = {
             None,
             {
                 "remote hosts": "localhost",
+                "name": "localhost",
                 "batch system": "background"
             },
         ),


### PR DESCRIPTION
### Summary
- Refactor the tests using latest Syntax.
- Fix `platform_from_name` to return `[platform]remote hosts = [platform name]` if remote hosts not set.