### PR TITLE
Plumbing.fix auth keys

### DIFF
--- a/tests/authentication/01-remote-suite-same-name.t
+++ b/tests/authentication/01-remote-suite-same-name.t
@@ -30,11 +30,11 @@ SSH_OPTS='-oBatchMode=yes -oConnectTimeout=5'
 # shellcheck disable=SC2029,SC2086
 ssh ${SSH_OPTS} "${CYLC_TEST_HOST}" mkdir -p "cylc-run/${SUITE_NAME}"
 # shellcheck disable=SC2086
-scp "${SSH_OPTS}" -pqr "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/"* \
+scp ${SSH_OPTS} -pqr "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/"* \
     "${CYLC_TEST_HOST}:cylc-run/${SUITE_NAME}"
 # shellcheck disable=SC2086
 run_ok "${TEST_NAME_BASE}-register" \
-    ssh "${SSH_OPTS}" "${CYLC_TEST_HOST}" \
+    ssh ${SSH_OPTS} "${CYLC_TEST_HOST}" \
     cylc register "${SUITE_NAME}" "cylc-run/${SUITE_NAME}"
 
 suite_run_ok "${TEST_NAME_BASE}" \

--- a/tests/authentication/04-check-keys-remote.t
+++ b/tests/authentication/04-check-keys-remote.t
@@ -17,24 +17,29 @@
 #-------------------------------------------------------------------------------
 # Checks remote ZMQ keys are created and deleted on shutdown.
 . "$(dirname "$0")/test_header"
-set_test_remote_host
+
+require_remote_platform
+
 set_test_number 4
+
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+#!jinja2
 [cylc]
 [scheduling]
     [[graph]]
         R1 = holder => held
 [runtime]
-    [[holder]]    
+    [[holder]]
         script = """cylc hold "${CYLC_SUITE_NAME}" """
-        [[[remote]]]
-            host = $CYLC_TEST_HOST
+        platform = {{CYLC_REMOTE_PLATFORM}}
     [[held]]
         script = true
 __SUITE_RC__
 
-run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" 
-suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" 
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
+    -s "CYLC_REMOTE_PLATFORM=${CYLC_REMOTE_PLATFORM}"
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" \
+    -s "CYLC_REMOTE_PLATFORM=${CYLC_REMOTE_PLATFORM}"
 RRUND="cylc-run/${SUITE_NAME}"
 RSRVD="${RRUND}/.service"
 poll_grep_suite_log 'Holding all waiting or queued tasks now'


### PR DESCRIPTION
- Fix a test (`authentication/04`) written in the idiom of `hosts` for use in the new world of `platforms`. 
- Fix a test (`authentication/01`) where I slavishly added double quotes where double quotes ought not have been.