### PR TITLE
sped up tests/functional/execution-time-limit/02-slurm

### DIFF
--- a/tests/functional/cylc-poll/06-loadleveler.t
+++ b/tests/functional/cylc-poll/06-loadleveler.t
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test "cylc poll" for loadleveler, slurm, or pbs jobs.
+# TODO Check this test on a dockerized system or VM.
 export CYLC_TEST_IS_GENERIC=false
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
@@ -31,6 +32,14 @@ then
 fi
 export CYLC_TEST_BATCH_TASK_HOST CYLC_TEST_BATCH_SITE_DIRECTIVES
 set_test_number 2
+
+create_test_globalrc "" "
+[platforms]
+    [[loadleveler-platform]]
+        remote hosts = $CYLC_TEST_BATCH_TASK_HOST
+        batch system = loadleveler
+"
+
 reftest
 if [[ "${CYLC_TEST_BATCH_TASK_HOST}" != 'localhost' ]]; then
     purge_suite_remote "${CYLC_TEST_BATCH_TASK_HOST}" "${SUITE_NAME}"

--- a/tests/functional/cylc-poll/06-loadleveler/suite.rc
+++ b/tests/functional/cylc-poll/06-loadleveler/suite.rc
@@ -6,11 +6,7 @@
     [[a]]
         script = sleep 20
 {% if "CYLC_TEST_BATCH_TASK_HOST" in environ and environ["CYLC_TEST_BATCH_TASK_HOST"] %}
-        [[[remote]]]
-            host={{environ["CYLC_TEST_BATCH_TASK_HOST"]}}
-{% endif %}
-        [[[job]]]
-            batch system = loadleveler
+        platform = loadleveler-platform
         [[[directives]]]
             class=serial
             job_type=serial

--- a/tests/functional/directives/00-loadleveler.t
+++ b/tests/functional/directives/00-loadleveler.t
@@ -19,6 +19,7 @@
 #     This test requires an e.g. [test battery][batch systems][loadleveler]host
 #     entry in site/user config in order to run 'loadleveler' tests (same for
 #     slurm, pbs, etc), otherwise it will be bypassed.
+# TODO Check this test on a dockerized system or VM.
 export CYLC_TEST_IS_GENERIC=false
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------

--- a/tests/functional/execution-time-limit/02-slurm.t
+++ b/tests/functional/execution-time-limit/02-slurm.t
@@ -33,6 +33,14 @@ fi
 export CYLC_TEST_BATCH_TASK_HOST CYLC_TEST_BATCH_SITE_DIRECTIVES
 set_test_number 3
 
+create_test_globalrc "" "
+    [platforms]
+        [[test-slurm]]
+            batch system = $CYLC_TEST_BATCH_SYS
+            remote hosts = $CYLC_TEST_BATCH_TASK_HOST
+"
+
+
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
@@ -42,7 +50,7 @@ run_ok "${TEST_NAME_BASE}-validate" \
     -s "CYLC_TEST_BATCH_SITE_DIRECTIVES=${CYLC_TEST_BATCH_SITE_DIRECTIVES}" \
     "${SUITE_NAME}"
 
-suite_run_ok "${TEST_NAME_BASE}-run" \
+suite_run_fail "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach \
     -s "CYLC_TEST_BATCH_SYS=${CYLC_TEST_BATCH_SYS}" \
     -s "CYLC_TEST_BATCH_TASK_HOST=${CYLC_TEST_BATCH_TASK_HOST}" \
@@ -50,7 +58,7 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
     "${SUITE_NAME}"
 
 LOGD="$RUN_DIR/${SUITE_NAME}/log/job/1/foo"
-grep_ok '#SBATCH --time=1:10' "${LOGD}/01/job"
+grep_ok '#SBATCH --time=0:05' "${LOGD}/01/job"
 
 if [[ "${CYLC_TEST_BATCH_TASK_HOST}" != 'localhost' ]]; then
     purge_suite_remote "${CYLC_TEST_BATCH_TASK_HOST}" "${SUITE_NAME}"

--- a/tests/functional/execution-time-limit/02-slurm/suite.rc
+++ b/tests/functional/execution-time-limit/02-slurm/suite.rc
@@ -1,4 +1,8 @@
 #!jinja2
+[cylc]
+    [[events]]
+        inactivity = PT2S
+
 [scheduling]
     [[graph]]
         R1 = foo
@@ -10,12 +14,9 @@ if [[ "${CYLC_TASK_SUBMIT_NUMBER}" == '1' ]]; then
     sleep 300
 fi
 """
-        [[[remote]]]
-            host={{CYLC_TEST_BATCH_TASK_HOST}}
+        platform = test-slurm
         [[[job]]]
-            batch system = {{CYLC_TEST_BATCH_SYS}}
-            execution time limit = PT70S
+            execution time limit = PT5S
             execution retry delays = PT0S
         [[[directives]]]
             {{CYLC_TEST_BATCH_SITE_DIRECTIVES}}
-

--- a/tests/functional/job-file-trap/01-loadleveler.t
+++ b/tests/functional/job-file-trap/01-loadleveler.t
@@ -19,6 +19,7 @@
 # A job for a task with the restart=yes directive will have the trap.
 # This does not test loadleveler job vacation itself, because the test will
 # require a site admin to pre-empt a job.
+# TODO Check this test on a dockerized system or VM.
 export CYLC_TEST_IS_GENERIC=false
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------

--- a/tests/functional/job-kill/02-loadleveler.t
+++ b/tests/functional/job-kill/02-loadleveler.t
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test killing of jobs submitted to loadleveler, slurm, pbs...
+# TODO Check this test on a dockerized system or VM.
 export CYLC_TEST_IS_GENERIC=false
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This test now only checks that a task with an execution time limit stops in the correct way.
It no longer covers the parsing of `execution time limits` < 1m, becuase this is covered by `tests/unit/batch_sys_handlers/test_slurm` and was slowing the execution of the functional test considerably.
