### PR TITLE
Plumbing.remove task proxy summary hosts

### DIFF
--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -798,7 +798,7 @@ class TaskEventsManager():
                 '[%s] -job[%02d] submitted to %s:%s[%s]',
                 itask,
                 itask.summary['submit_num'],
-                itask.summary['host'],
+                itask.summary['platforms_used'].values()[-1],
                 itask.summary['batch_sys_name'],
                 itask.summary['submit_method_id'])
         except KeyError:
@@ -926,7 +926,9 @@ class TaskEventsManager():
             # Note: user@host may not always be set for a submit number, e.g.
             # on late event or if host select command fails. Use null string to
             # prevent issues in this case.
-            user_at_host = itask.summary['job_hosts'].get(itask.submit_num, '')
+            user_at_host = itask.summary['platforms_used'].get(
+                itask.submit_num, ''
+            )
             if user_at_host and '@' not in user_at_host:
                 # (only has 'user@' on the front if user is not suite owner).
                 user_at_host = '%s@%s' % (get_user(), user_at_host)

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -669,18 +669,16 @@ class TaskJobManager(object):
         # sort itasks into lists based upon where they were run.
         auth_itasks = {}
         for itask in itasks:
-            # retrieve owner and host used last time
-            host = itask.summary['job_hosts'][max(itask.summary['job_hosts'])]
-            owner = ''
-            if 'owner' in itask.summary:
-                owner = itask.summary['owner']
-            platform_name = itask.platform['name']
-            if (platform_name, host, owner) not in auth_itasks:
-                auth_itasks[(platform_name, host, owner)] = []
-            auth_itasks[(platform_name, host, owner)].append(itask)
+            # retrieve platform used last time
+            platform_n = itask.summary['platforms_used'][max(
+                itask.summary['platforms_used']
+            )]
+            if (platform_n) not in auth_itasks:
+                auth_itasks[platform_n] = []
+            auth_itasks[platform_n].append(itask)
 
         # Go through each list of itasks and carry out commands as required.
-        for (platform_n, host, owner), itasks in sorted(auth_itasks.items()):
+        for platform_n, itasks in sorted(auth_itasks.items()):
             platform = platform_from_name(platform_n)
             if is_remote_platform(platform):
                 remote_mode = True
@@ -872,16 +870,8 @@ class TaskJobManager(object):
         """Helper for self._prep_submit_task_job."""
         # itask.platform is going to get boring...
         platform = itask.platform
-        host = get_host_from_platform(platform)
-        owner = platform['owner']
 
-        if owner:
-            owner_at_host = f"{owner}@{host}"
-        else:
-            owner_at_host = host
-
-        itask.summary['host'] = owner_at_host
-        itask.summary['job_hosts'][itask.submit_num] = owner_at_host
+        itask.summary['platforms_used'][itask.submit_num] = platform['name']
 
         itask.summary['batch_sys_name'] = platform['batch system']
         for name in rtconfig['extra log files']:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -420,7 +420,8 @@ class TaskPool(object):
                         pass
 
             if platform_name:
-                itask.summary['job_hosts'][int(submit_num)] = platform_name
+                itask.summary['platforms_used'][
+                    int(submit_num)] = platform_name
             LOG.info("+ %s.%s %s%s" % (
                 name, cycle, status, ' (held)' if is_held else ''))
             self.add_to_runahead_pool(itask, is_new=False)
@@ -1188,7 +1189,7 @@ class TaskPool(object):
             if back_out:
                 # (Aborted edit-run, reset for next trigger attempt).
                 try:
-                    del itask.summary['job_hosts'][itask.submit_num]
+                    del itask.summary['platforms_used'][itask.submit_num]
                 except KeyError:
                     pass
                 job_d = get_task_job_id(

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -85,8 +85,8 @@ class TaskProxy(object):
                 Latest job exit time.
             finished_time_string (str):
                 Latest job exit time as string.
-            job_hosts (dict):
-                Jobs' owner@host by submit number.
+            platforms_used (dict):
+                Jobs' platform names by submit number.
             label (str):
                 The .point attribute as string.
             latest_message (str):
@@ -221,7 +221,7 @@ class TaskProxy(object):
             'finished_time': None,
             'finished_time_string': None,
             'logfiles': [],
-            'job_hosts': {},
+            'platforms_used': {},
             'execution_time_limit': None,
             'batch_sys_name': None,
             'submit_method_id': None

--- a/tests/functional/cylc-trigger/07-edit-run-abort/bin/my-suite-state-summary-test
+++ b/tests/functional/cylc-trigger/07-edit-run-abort/bin/my-suite-state-summary-test
@@ -14,7 +14,7 @@ def main():
     summary = json.load(sys.stdin)[1]['victim.1']
     sys.stderr.write('%s' % summary)
     assert(summary['submit_num'] == 1)
-    assert(len(summary['job_hosts']) == 1)
+    assert(len(summary['platforms_used']) == 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As per comment on plumbing -> cylc/master by Oliver - replace usage of `summary['remote_hosts']` in task proxy object with a more platform orientated name.