### PR TITLE
make dummy-local mode use platforms

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1281,8 +1281,7 @@ class SuiteConfig(object):
 
             if tdef.run_mode == 'dummy-local':
                 # Run all dummy tasks on the suite host.
-                rtc['remote']['host'] = None
-                rtc['remote']['owner'] = None
+                rtc['platform'] = 'localhost'
 
             # Simulation mode tasks should fail in which cycle points?
             f_pts = []

--- a/tests/flakyfunctional/modes/03-dummy-env/suite.rc
+++ b/tests/flakyfunctional/modes/03-dummy-env/suite.rc
@@ -10,7 +10,6 @@
             default run length = PT0S
     [[oxygas]]
         env-script = ELSE=foo
-        [[[remote]]]
-            host = whatever
+        platform = 'whateva'
         [[[environment]]]
             SOMETHING = "some-modification-$ELSE"


### PR DESCRIPTION
Minor follow up issue to platforms: `dummy-local` mode should force task platforms rather than owners@hosts.