### PR TITLE
get-resources: stuff

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -309,9 +309,11 @@ class Scheduler:
 
         # Extract job.sh from library, for use in job scripts.
         get_resources(
+            'job.sh',
             os.path.join(
-                workflow_files.get_workflow_srv_dir(self.workflow), 'etc',),
-            ['etc/job.sh'])
+                workflow_files.get_workflow_srv_dir(self.workflow), 'etc',
+            ),
+        )
         # Add python dirs to sys.path
         for sub_dir in ["python", os.path.join("lib", "python")]:
             # TODO - eventually drop the deprecated "python" sub-dir.

--- a/cylc/flow/task_remote_cmd.py
+++ b/cylc/flow/task_remote_cmd.py
@@ -148,7 +148,9 @@ def remote_init(install_target: str, rund: str, *dirs_to_symlink: str) -> None:
     os.chdir(rund)
     # Extract job.sh from library, for use in job scripts.
     get_resources(
-        os.path.join(WorkflowFiles.Service.DIRNAME, 'etc'), ['etc/job.sh'])
+        'job.sh',
+        os.path.join(WorkflowFiles.Service.DIRNAME, 'etc')
+    )
     try:
         tarhandle = tarfile.open(fileobj=sys.stdin.buffer, mode='r|')
         tarhandle.extractall()


### PR DESCRIPTION
Apologies, I completely forgot about something important in the old `rose tutorial` command.

It had a purposefully undocumented feature where it replaced a placeholder with a real API key chosen at random from some file. Without this the tutorials were broken for no fault of their own.

I also spotted some issues with the pre-existing `get-resources` command, namely the `DIR` arg. Rather than push it back and forth in review with little time remaining I had a crack.

* Remove the `etc/` prefix from resource names.
* Fixes invisible DIR argument (did not appear in --help output).
* Limit to extracting one resource (or directory) at a time.
  * Makes the interface much clearer.
  * Fixes a bug / documentation issue where [DIR] is considered optional
    (if was missing the last resource name was used as DIR).
* List tutorials as well as resources.
* Replace the API key placeholder in tutorials after copying.
* Remove the `--tutorial` option (can infer this from the resource
  path).
* Fixes possible Path issues with shutil
