### PR TITLE
UUID followup

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -305,8 +305,6 @@ class Scheduler:
             pub_d=os.path.join(self.workflow_run_dir, 'log')
         )
         self.is_restart = Path(self.workflow_db_mgr.pri_path).is_file()
-        if not self.is_restart:
-            self.uuid_str = str(uuid4())
 
         # Map used to track incomplete remote inits for restart
         # {install_target: platform}
@@ -426,6 +424,8 @@ class Scheduler:
 
         if self.is_restart:
             self.load_workflow_params_and_tmpl_vars()
+        else:
+            self.uuid_str = str(uuid4())
 
         self.profiler.log_memory("scheduler.py: before load_flow_file")
         try:
@@ -703,7 +703,6 @@ class Scheduler:
 
             await self.configure()
             self.task_events_mgr.uuid_str = self.uuid_str
-            self.task_job_mgr.task_remote_mgr.uuid_str = self.uuid_str
             self._configure_contact()
         except (KeyboardInterrupt, asyncio.CancelledError, Exception) as exc:
             await self.handle_exception(exc)

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -186,7 +186,7 @@ class EventData(Enum):
 
     .. deprecated:: 8.0.0
 
-       Use 'uuid_str'.
+       Use 'uuid'.
     """
 
     CyclePoint = 'point'

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1324,7 +1324,7 @@ class TaskJobManager:
             'workflow_name': workflow,
             'task_id': itask.identity,
             'try_num': itask.get_try_num(),
-            'uuid_str': self.task_remote_mgr.uuid_str,
+            'uuid_str': self.task_events_mgr.uuid_str,
             'work_d': rtconfig['work sub-directory'],
             # this field is populated retrospectively for regular job subs
             'logfiles': [],
@@ -1357,7 +1357,7 @@ class TaskJobManager:
             'workflow_name': workflow,
             'task_id': itask.identity,
             'try_num': itask.get_try_num(),
-            'uuid_str': self.task_remote_mgr.uuid_str,
+            'uuid_str': self.task_events_mgr.uuid_str,
             'work_d': 'SIMULATION',
             # this field is populated retrospectively for regular job subs
             'logfiles': [],

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -103,7 +103,6 @@ class TaskRemoteMgr:
         self.remote_command_map = {}
         # self.remote_init_map = {(install target): status, ...}
         self.remote_init_map = {}
-        self.uuid_str = None
         # This flag is turned on when a host init/select command completes
         self.ready = False
         self.rsync_includes = None

--- a/cylc/flow/workflow_events.py
+++ b/cylc/flow/workflow_events.py
@@ -107,7 +107,7 @@ class EventData(Enum):
 
     .. deprecated:: 8.0.0
 
-       Use "uuid_str".
+       Use "uuid".
     """
 
     # BACK COMPAT: "suite_url" deprecated

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -199,13 +199,13 @@ async def myflow(mod_flow, mod_scheduler, mod_one_conf):
 
 
 def test_module_scoped_fixture(myflow):
-    """Ensure the uuid is set on __init__.
+    """Ensure the host is set on __init__.
 
     The myflow fixture will be shared between all test functions within this
     Python module.
 
     """
-    assert myflow.uuid_str
+    assert myflow.host
 
 
 async def test_db_select(one, start, db_select):

--- a/tests/integration/test_workflow_files.py
+++ b/tests/integration/test_workflow_files.py
@@ -19,6 +19,7 @@ import logging
 from os import unlink
 from pathlib import Path
 from textwrap import dedent
+from uuid import uuid4
 
 import pytest
 
@@ -69,6 +70,7 @@ async def workflow(flow, scheduler, one_conf, run_dir):
     from collections import namedtuple
     Server = namedtuple('Server', ['port', 'pub_port'])
     schd.server = Server(1234, pub_port=2345)
+    schd.uuid_str = str(uuid4())
 
     contact_data = schd.get_contact_data()
     contact_file = Path(


### PR DESCRIPTION
- Set Scheduler UUID at same place regardless of restart or not
- Fix references to "uuid_str" -> "uuid" in docs
- Tidy